### PR TITLE
koeyhk / 2월 1주차 / 7문제

### DIFF
--- a/koeyhk/BAEKJOON/구현/4920 테트리스 게임.py
+++ b/koeyhk/BAEKJOON/구현/4920 테트리스 게임.py
@@ -1,0 +1,49 @@
+# N = 100
+# O(N^4)까지 가능
+
+# 풀이 아이디어
+# ㅣ와 ㅡ, 그리고 ㅁ는 따로 처리하고, 다른 블록은 2*3 배열로 묶어서 회전해 처리
+# 인덱스에 주의해야 함!
+
+import sys
+input_data = sys.stdin.readline
+
+block = [[[1, 1, 0], [0, 1, 1]], [[1, 1, 1], [0, 0, 1]], [[1, 1, 1], [0, 1, 0]], [[1, 1], [1, 1]]]
+
+
+def rotation(block):
+    n = len(block)  # 2
+    m = len(block[0])  # 3
+    tmp = [[0]*n for _ in range(m)]
+    for j in range(m):  # 3
+        for i in range(n):  # 2
+            tmp[j][i] = block[n-i-1][j]
+    return tmp
+
+
+p = 1
+while 1:
+    result = -10e9
+    N = int(input_data())
+    if N == 0:
+        break
+    board = [list(map(int, input_data().split())) for _ in range(N)]
+    for i in range(N):      # O(N^2) * O(4*3*6)
+        for j in range(N):
+            for k in range(3):      # 블록에 돌아가는 for 문
+                for _ in range(4):      # 90도 방향을 회전 4번 수행
+                    block[k] = rotation(block[k])
+                    if len(block[k][0]) + j <= N and len(block[k]) + i <= N:    # 범위 확인
+                        r = 0
+                        for x in range(len(block[k])):
+                            for y in range(len(block[k][0])):
+                                r += block[k][x][y] * board[i+x][j+y]
+                        result = max(result, r)
+                if i < N-1 and j < N-1:     # 정사각형 블록
+                    result = max(result, board[i][j] + board[i][j+1] + board[i+1][j] + board[i+1][j+1])
+                if j <= N-4:    # ㅡ 블록
+                    result = max(result, board[i][j] + board[i][j+1] + board[i][j+2] + board[i][j+3])
+                if i <= N-4:    # ㅣ 블록
+                    result = max(result, board[i][j] + board[i+1][j] + board[i+2][j] + board[i+3][j])
+    print(str(p)+'. ' + str(result))
+    p += 1

--- a/koeyhk/BAEKJOON/누적 합/11660 구간 합 구하기 5.py
+++ b/koeyhk/BAEKJOON/누적 합/11660 구간 합 구하기 5.py
@@ -1,0 +1,44 @@
+# N = 1024, M = 100,000
+# 성능 개선 풀이
+# x, y까지 누적합을 구한 결과 저장 -> O(MN) -> O(N^2) 시간 단축
+
+import sys
+
+input_data = sys.stdin.readline
+
+N, M = map(int, input_data().split())
+board = [list(map(int, input_data().split())) for _ in range(N)]
+dp = [[0]*(N+1) for _ in range(N+1)]
+s = 0
+for i in range(1, N+1):      # O(N^2)
+    for j in range(1, N+1):
+        dp[i][j] = dp[i][j-1] + dp[i-1][j] - dp[i-1][j-1] + board[i-1][j-1]
+for _ in range(M):      # O(M)
+    x1, y1, x2, y2 = map(int, input_data().split())
+    result = dp[x2][y2] - dp[x1-1][y2] - dp[x2][y1-1] + dp[x1-1][y1-1]
+    print(result)
+
+
+# 이전 풀이
+# x, y까지 모든 요소합을 구한 결과 저장 -> O(MN)
+# Python3으로 통과 x, pypy3로 통과
+
+import sys
+
+input_data = sys.stdin.readline
+
+N, M = map(int, input_data().split())
+board = [list(map(int, input_data().split())) for _ in range(N)]
+sum_b = [[0]*N for _ in range(N)]
+s = 0
+for i in range(N):      # O(N^2)
+    for j in range(N):
+        s += board[i][j]
+        sum_b[i][j] = s
+for _ in range(M):      # O(MN)
+    x1, y1, x2, y2 = map(int, input_data().split())
+    x1, y1, x2, y2 = x1-1, y1-1, x2-1, y2-1
+    result = 0
+    for i in range(x1, x2+1):
+        result += sum_b[i][y2] - sum_b[i][y1] + board[i][y1]
+    print(result)

--- a/koeyhk/BAEKJOON/누적 합/1749 점수따먹기.py
+++ b/koeyhk/BAEKJOON/누적 합/1749 점수따먹기.py
@@ -1,0 +1,20 @@
+# N, M = 200
+# 누적합 -> 부분행렬 마다 확인하기
+
+import sys
+
+input_data = sys.stdin.readline
+
+N, M = map(int, input_data().split())
+matrix = [list(map(int, input_data().split())) for _ in range(N)]
+dp = [[0]*(M+1) for _ in range(N+1)]
+for i in range(1, N+1):
+    for j in range(1, M+1):
+        dp[i][j] = dp[i-1][j] + dp[i][j-1] - dp[i-1][j-1] + matrix[i-1][j-1]
+result = -10e9
+for i in range(1, N+1):
+    for j in range(1, M+1):
+        for k in range(i, N+1):
+            for h in range(j, M+1):
+                result = max(result, dp[k][h] - dp[i-1][h] - dp[k][j-1] + dp[i-1][j-1])
+print(result)

--- a/koeyhk/BAEKJOON/스택/9935 문자열 폭발.py
+++ b/koeyhk/BAEKJOON/스택/9935 문자열 폭발.py
@@ -1,0 +1,30 @@
+# 모든 폭발 문자열 폭발 -> 남은 문자열 이어붙임
+# 새로 생긴 문자열에도 폭발 확인
+# 폭발 문자열은 같은 문자 중복 x
+# N = 1,000,000
+
+# 생각하지 못한 것
+# 문자열을 지우고 앞으로 이동할 필요없이 stack을 사용해서 현재 들어온 문자에 따라 비교
+# 폭발 문자열은 같은 문자 중복되지 않기 때문!!
+
+# 잘못된 비교
+# 문자열과 리스트 비교 x -> 리스트를 문자열로 바꾸거나 문자열을 리스트로 바꿔야함
+
+import sys
+
+input_data = sys.stdin.readline
+
+str = input_data().rstrip()
+bomb_str = input_data().rstrip()
+b = len(bomb_str)
+stack = []
+for i in str:
+    stack.append(i)
+    if i == bomb_str[-1] and ''.join(stack[len(stack)-b:]) == bomb_str:
+        for _ in range(b):
+            stack.pop()
+
+if stack:
+    print(''.join(stack))
+else:
+    print("FRULA")

--- a/koeyhk/BAEKJOON/정렬/8979 올림픽.py
+++ b/koeyhk/BAEKJOON/정렬/8979 올림픽.py
@@ -1,0 +1,22 @@
+# N, K = 1000
+# K 국가의 등수만 알면 됨
+# O(N) -> 정렬 후 K 국가 찾고 K 앞에서 동점 국가 확인
+
+import sys
+
+input_data = sys.stdin.readline
+
+N, K = map(int, input_data().split())
+country = [list(map(int, input_data().split())) for _ in range(N)]
+country.sort(key=lambda x: (-x[1], -x[2], -x[3]))
+for i in range(N):
+    if country[i][0] == K:
+        c = i
+        break
+result = c+1
+for i in range(c-1, -1, -1):
+    if country[i][1:] == country[c][1:]:
+        result -= 1
+    else:
+        break
+print(result)

--- a/koeyhk/BAEKJOON/투포인터/21921 블로그.py
+++ b/koeyhk/BAEKJOON/투포인터/21921 블로그.py
@@ -1,0 +1,28 @@
+# N, X = 250,000
+# O(N) -> 투 포인터 (슬라이딩 윈도우)
+# l, l+X-1 -> l 증가하면서 비교
+
+import sys
+
+input_data = sys.stdin.readline
+
+N, X = map(int, input_data().split())
+visit = list(map(int, input_data().split()))
+sum_x = sum(visit[:X])
+result = sum_x
+l = 0
+period = 1
+while l+X < N:
+    sum_x = sum_x - visit[l] + visit[l+X]
+    if result < sum_x:
+        period = 1
+        result = sum_x
+    elif result == sum_x:
+        period += 1
+    l += 1
+
+if result:
+    print(result)
+    print(period)
+else:
+    print("SAD")

--- a/koeyhk/BAEKJOON/투포인터/2559 수열.py
+++ b/koeyhk/BAEKJOON/투포인터/2559 수열.py
@@ -1,0 +1,16 @@
+# N, K = 100,000
+# O(N) -> 투포인터
+
+import sys
+
+input_data = sys.stdin.readline
+
+N, K = map(int, input_data().split())
+num = list(map(int, input_data().split()))
+
+l, r = 0, K-1
+result = sum(num[0:K])
+answer = result
+for i in range(0, N-K):
+    result = result - num[i] + num[i+K]
+    answer = max(answer, result)


### PR DESCRIPTION
### 1. 투 포인터

수열
- O(N)으로 해결 -> 투 포인터

블로그
- 슬라이딩 윈도우 -> 윈도우 크기 동일

### 2. 누적합

구간 합 구하기 5
- 처음 풀이: x, y까지 모든 요소합을 구한 결과 저장 후 계산 -> O(MN)
- 개선된 풀이: x, y까지 누적합을 구한 결과 저장 -> O(N^2) 시간 단축

### 3. 정렬

올림픽
- K 국가의 등수만 알면 됨
- O(N) -> 정렬 후 K 국가 찾고 K 앞에서 동점 국가 확인

### 4. 구현

테트리스 게임
- ㅣ와 ㅡ, 그리고 ㅁ는 따로 처리하고, 다른 블록은 2*3 배열로 묶어서 회전해 처리
- 인덱스에 주의해야 함!

### 5. 누적합

점수따먹기
- 누적합 -> 부분행렬 마다 확인하기

### 6. 스택

문자열 폭발
- 문자열을 지우고 앞으로 이동할 필요없이 stack을 사용해서 현재 들어온 문자에 따라 비교
- 문자열과 리스트 비교 x -> 리스트를 문자열로 바꾸거나 문자열을 리스트로 바꿔야함